### PR TITLE
Hotfix steven project end date

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ dist/
 .yarn/
 .vscode/
 **/header.ejs
+*.ejs

--- a/public/scripts/portal/projects/edit.js
+++ b/public/scripts/portal/projects/edit.js
@@ -1,5 +1,17 @@
 // JS File for Portal Project Edit View
 
+jQuery.validator.addMethod("greaterThan", 
+function(value, element, params) {
+	if (!value) return true;
+
+    if (!/Invalid|NaN/.test(new Date(value))) {
+        return new Date(value) > new Date($(params).val());
+    }
+
+    return isNaN(value) && isNaN($(params).val()) 
+        || (Number(value) > Number($(params).val())); 
+}, 'End date must be after the start date.');
+
 $(function () {
 	$('#frm').validate({
 		ignore: ':hidden',
@@ -11,7 +23,8 @@ $(function () {
 			txtTestLink: { required: true, maxlength: 150 },
 			txtGithub: { required: true, maxlength: 150 },
 			txtImageLink: { required: true, maxlength: 500 },
-			txtDate: { required: true },
+			txtStartDate: { required: true },
+			txtEndDate: { required: false, greaterThan: '#txtStartDate' }
 		},
 		errorPlacement: function (error, element) {
 			error.appendTo(element.closest('.form-group'));

--- a/public/scripts/portal/projects/edit.js
+++ b/public/scripts/portal/projects/edit.js
@@ -1,16 +1,21 @@
 // JS File for Portal Project Edit View
 
-jQuery.validator.addMethod("greaterThan", 
-function(value, element, params) {
-	if (!value) return true;
+jQuery.validator.addMethod(
+	'greaterThan',
+	function (value, element, params) {
+		if (!value) return true;
 
-    if (!/Invalid|NaN/.test(new Date(value))) {
-        return new Date(value) > new Date($(params).val());
-    }
+		if (!/Invalid|NaN/.test(new Date(value))) {
+			return new Date(value) > new Date($(params).val());
+		}
 
-    return isNaN(value) && isNaN($(params).val()) 
-        || (Number(value) > Number($(params).val())); 
-}, 'End date must be after the start date.');
+		return (
+			(isNaN(value) && isNaN($(params).val())) ||
+			Number(value) > Number($(params).val())
+		);
+	},
+	'End date must be after the start date.'
+);
 
 $(function () {
 	$('#frm').validate({
@@ -24,7 +29,7 @@ $(function () {
 			txtGithub: { required: true, maxlength: 150 },
 			txtImageLink: { required: true, maxlength: 500 },
 			txtStartDate: { required: true },
-			txtEndDate: { required: false, greaterThan: '#txtStartDate' }
+			txtEndDate: { required: false, greaterThan: '#txtStartDate' },
 		},
 		errorPlacement: function (error, element) {
 			error.appendTo(element.closest('.form-group'));

--- a/routes/portal/projects.js
+++ b/routes/portal/projects.js
@@ -39,7 +39,7 @@ router.put('/edit/:id', middleware.checkAuthenticated, function (req, res) {
 	var sqlQuery =
 		'UPDATE tbl_projects ' +
 		'SET name = @name, work_done = @work_done, status = @status, manager = @manager, test_url = @test_url, github_url = @github_url, ' +
-		'start_date = @start_date, deleted = @deleted, image_url = @image_url WHERE id=@id';
+		'start_date = @start_date, end_date = @end_date, deleted = @deleted, image_url = @image_url WHERE id=@id';
 
 	sqlReq.input('id', sql.Int, req.params.id);
 	sqlReq.input('name', sql.NVarChar, req.body.txtName);
@@ -50,7 +50,8 @@ router.put('/edit/:id', middleware.checkAuthenticated, function (req, res) {
 	sqlReq.input('image_url', sql.NVarChar, req.body.txtImageLink);
 	sqlReq.input('test_url', sql.NVarChar, req.body.txtTestLink);
 	sqlReq.input('github_url', sql.NVarChar, req.body.txtGithub);
-	sqlReq.input('start_date', sql.NVarChar, req.body.txtDate);
+	sqlReq.input('start_date', sql.NVarChar, req.body.txtStartDate);
+	sqlReq.input('end_date', sql.NVarChar, req.body.txtEndDate);
 
 	sqlReq
 		.query(sqlQuery)
@@ -77,12 +78,12 @@ router.post('/new', middleware.checkAuthenticated, function (req, res) {
 	var sqlReq = new sql.Request();
 
 	var sqlQuery =
-		'INSERT INTO tbl_projects (name, work_done, status, manager, test_url, github_url, start_date, deleted, image_url) VALUES ' +
-		'(@name, @work_done, @status, @manager, @test_url, @github_url, @start_date, @deleted,  @image_url)';
+		'INSERT INTO tbl_projects (name, work_done, status, manager, test_url, github_url, start_date, end_date, deleted, image_url) VALUES ' +
+		'(@name, @work_done, @status, @manager, @test_url, @github_url, @start_date, @end_date, @deleted,  @image_url)';
 
 	var queryText =
-		'INSERT INTO tbl_projects (name, work_done, status, manager, test_url, github_url, start_date, deleted, image_url) VALUES ' +
-		'(@name, @work_done, @status, @manager, @test_url, @github_url, @start_date, @deleted,  @image_url)';
+		'INSERT INTO tbl_projects (name, work_done, status, manager, test_url, github_url, start_date, end_date, deleted, image_url) VALUES ' +
+		'(@name, @work_done, @status, @manager, @test_url, @github_url, @start_date, @end_date, @deleted,  @image_url)';
 
 	sqlReq.input('id', sql.Int, req.params.id);
 	sqlReq.input('name', sql.NVarChar, req.body.txtName);
@@ -93,7 +94,8 @@ router.post('/new', middleware.checkAuthenticated, function (req, res) {
 	sqlReq.input('image_url', sql.NVarChar, req.body.txtImageLink);
 	sqlReq.input('test_url', sql.NVarChar, req.body.txtTestLink);
 	sqlReq.input('github_url', sql.NVarChar, req.body.txtGithub);
-	sqlReq.input('start_date', sql.NVarChar, req.body.txtDate);
+	sqlReq.input('start_date', sql.NVarChar, req.body.txtStartDate);
+	sqlReq.input('end_date', sql.NVarChar, req.body.txtEndDate);
 
 	sqlReq
 		.query(sqlQuery)

--- a/views/portal/projects/edit.ejs
+++ b/views/portal/projects/edit.ejs
@@ -1,9 +1,12 @@
-<%- include('../partials/header') %> <% var startDateFormatted= ""; if
-(project.start_date) { var temp_date = new Date(project.start_date);
-startDateFormatted = temp_date.toISOString().split('T')[0]; } %>
-<% var endDateFormatted= ""; if
-(project.end_date) { var temp_date = new Date(project.end_date);
-endDateFormatted = temp_date.toISOString().split('T')[0]; } %>
+<%- include('../partials/header') %>
+<% var startDateFormatted= "";
+if (project.start_date) { var temp_date = new Date(project.start_date);
+startDateFormatted = temp_date.toISOString().split('T')[0]; } 
+var endDateFormatted= "";
+if (project.end_date && project.end_date.toLocaleDateString() !== '12/31/1899') {
+	var temp_date = new Date(project.end_date);
+	endDateFormatted = temp_date.toISOString().split('T')[0];
+}%>
 <div class="container">
 	<div class="row mt-5">
 		<div class="col-12">

--- a/views/portal/projects/edit.ejs
+++ b/views/portal/projects/edit.ejs
@@ -1,6 +1,9 @@
-<%- include('../partials/header') %> <% var dateFormatted= ""; if
+<%- include('../partials/header') %> <% var startDateFormatted= ""; if
 (project.start_date) { var temp_date = new Date(project.start_date);
-dateFormatted = temp_date.toISOString().split('T')[0]; } %>
+startDateFormatted = temp_date.toISOString().split('T')[0]; } %>
+<% var endDateFormatted= ""; if
+(project.end_date) { var temp_date = new Date(project.end_date);
+endDateFormatted = temp_date.toISOString().split('T')[0]; } %>
 <div class="container">
 	<div class="row mt-5">
 		<div class="col-12">
@@ -92,9 +95,19 @@ dateFormatted = temp_date.toISOString().split('T')[0]; } %>
 					<input
 						type="date"
 						class="form-control"
-						id="txtDate"
-						name="txtDate"
-						value="<%=dateFormatted%>"
+						id="txtStartDate"
+						name="txtStartDate"
+						value="<%=startDateFormatted%>"
+					/>
+				</div>
+				<div class="form-group">
+					<label for="txtDate">Project End Date</label>
+					<input
+						type="date"
+						class="form-control"
+						id="txtEndDate"
+						name="txtEndDate"
+						value="<%=endDateFormatted%>"
 					/>
 				</div>
 				<div class="form-check mt-3">

--- a/views/portal/projects/index.ejs
+++ b/views/portal/projects/index.ejs
@@ -33,13 +33,15 @@
 						</tr>
 					</thead>
 					<tbody>
-						<% projects.forEach(function(project) { var timeOffsetDate = new
-						Date(Date.now()); var timeOffset =
-						timeOffsetDate.getTimezoneOffset(); if (project.start_date) var
-						startDate = new Date(project.start_date.getTime() +
-						(timeOffset*60*1000)); if (project.end_date) var
-						endDate = new Date(project.end_date.getTime() +
-						(timeOffset*60*1000)); %>
+						<% projects.forEach(function(project) { 
+							var timeOffsetDate = new Date(Date.now()); 
+							var timeOffset = timeOffsetDate.getTimezoneOffset();
+							
+							if (project.start_date) 
+								var startDate = new Date(project.start_date.getTime() + (timeOffset*60*1000));
+							
+							if (project.end_date) 
+								var endDate = new Date(project.end_date.getTime() + (timeOffset*60*1000)); %>
 						<tr>
 							<td></td>
 							<td>
@@ -51,9 +53,12 @@
 							</td>
 							<td><%= project.work_done %></td>
 							<td><%= startDate.toLocaleDateString() %></td>
-							<% if (endDate && endDate.toLocaleDateString() !== '12/31/1899') { %>
+							<% if (endDate && endDate.toLocaleDateString() !== '12/31/1899') {
+							%>
 							<td><%= endDate.toLocaleDateString() %></td>
-							<% } else { %><td></td><% } %>
+							<% } else { %>
+							<td></td>
+							<% } %>
 							<td><%= project.manager %></td>
 							<% if (project.deleted == 1) { %>
 							<td class="red-danger">Deleted</td>

--- a/views/portal/projects/index.ejs
+++ b/views/portal/projects/index.ejs
@@ -27,6 +27,7 @@
 							<th>Name</th>
 							<th>Work Done</th>
 							<th>Start Date</th>
+							<th>End Date</th>
 							<th>Manager</th>
 							<th>Status</th>
 						</tr>
@@ -36,6 +37,8 @@
 						Date(Date.now()); var timeOffset =
 						timeOffsetDate.getTimezoneOffset(); if (project.start_date) var
 						startDate = new Date(project.start_date.getTime() +
+						(timeOffset*60*1000)); if (project.end_date) var
+						endDate = new Date(project.end_date.getTime() +
 						(timeOffset*60*1000)); %>
 						<tr>
 							<td></td>
@@ -48,6 +51,9 @@
 							</td>
 							<td><%= project.work_done %></td>
 							<td><%= startDate.toLocaleDateString() %></td>
+							<% if (endDate && endDate.toLocaleDateString() !== '12/31/1899') { %>
+							<td><%= endDate.toLocaleDateString() %></td>
+							<% } else { %><td></td><% } %>
 							<td><%= project.manager %></td>
 							<% if (project.deleted == 1) { %>
 							<td class="red-danger">Deleted</td>

--- a/views/portal/projects/new.ejs
+++ b/views/portal/projects/new.ejs
@@ -65,8 +65,12 @@
 					/>
 				</div>
 				<div class="form-group">
-					<label for="txtDate">Project Start Date</label>
-					<input type="date" class="form-control" id="txtDate" name="txtDate" />
+					<label for="txtStartDate">Project Start Date</label>
+					<input type="date" class="form-control" id="txtStartDate" name="txtStartDate" />
+				</div>
+				<div class="form-group">
+					<label for="txtEndDate">Project End Date</label>
+					<input type="date" class="form-control" id="txtEndDate" name="txtEndDate" value="" />
 				</div>
 				<div class="form-check mt-3">
 					<input

--- a/views/projects.ejs
+++ b/views/projects.ejs
@@ -3,7 +3,7 @@
 	var hasCompleted = false;
 	var hasCurrent = false;
 
-	for(var i = 0; i < projects.length; i++) {
+	for (var i = 0; i < projects.length; i++) {
 		if (projects[i].status == 'Completed') {
 			hasCompleted = true;
 		} else {

--- a/views/projects.ejs
+++ b/views/projects.ejs
@@ -4,50 +4,55 @@
 	var hasCurrent = false;
 
 	for(var i = 0; i < projects.length; i++) {
-			if (projects[i].status == 'Completed') {
-					hasCompleted = true;
-			} else {
-					hasCurrent = true;
-			}
+		if (projects[i].status == 'Completed') {
+			hasCompleted = true;
+		} else {
+			hasCurrent = true;		
+		}
 
+		if (projects[i].end_date && projects[i].end_date.toLocaleDateString() !== '12/31/1899') {
+			var seconds = Math.floor((projects[i].end_date - projects[i].start_date) / 1000);
+		} else {
 			var seconds = Math.floor((new Date() - projects[i].start_date) / 1000);
+		}
 
 		var interval = Math.floor(seconds / 31536000);
 
 		if (interval > 1) {
-			projects[i].start_date = interval + " years";
+			projects[i].duration = interval + " years";
 			continue;
 		}
 
 		interval = Math.floor(seconds / 2592000);
 
 		if (interval > 1) {
-			projects[i].start_date = interval + " months";
+			projects[i].duration = interval + " months";
 			continue;
 		}
 
 		interval = Math.floor(seconds / 86400);
 
 		if (interval > 1) {
-			projects[i].start_date = interval + " days";
+			projects[i].duration = interval + " days";
 			continue;
 		}
 
 		interval = Math.floor(seconds / 3600);
 
 		if (interval > 1) {
-			projects[i].start_date = interval + " hours";
+			projects[i].duration = interval + " hours";
 			continue;
 		}
 
 		interval = Math.floor(seconds / 60);
 
 		if (interval > 1) {
-			projects[i].start_date = interval + " minutes";
+			projects[i].duration = interval + " minutes";
 			continue;
 		}
 
-		projects[i].start_date = Math.floor(seconds) + " seconds";
+		projects[i].duration = Math.floor(seconds) + " seconds";
+
 	}
 %>
 			<div class=" text-center">
@@ -100,7 +105,7 @@
 																<a class="btn btn-purple mt-4" href="<%=project.test_url%>" target="_blank">Preview Site</a>
 															</p>
 															<div class="project-button-info">
-																<span class="project-timestamp" title="Project Duration"><i class="fas fa-clock mr-2"></i><%=project.start_date%></span>
+																<span class="project-timestamp" title="Project Duration"><i class="fas fa-clock mr-2"></i><%=project.duration%></span>
 															</div>
 															<div class="project-button-info mt-2">
 																<span class="project-timestamp" title="Current Status"><i class="fas fa-tasks mr-2"></i><%=project.status%></span>
@@ -151,7 +156,7 @@
 																<a class="btn btn-purple mt-4" href="<%=project.test_url%>" target="_blank">Preview Site</a>
 															</p>
 															<div class="project-button-info">
-																<span class="project-timestamp" title="Project Duration"><i class="fas fa-clock mr-2"></i><%=project.start_date%></span>
+																<span class="project-timestamp" title="Project Duration"><i class="fas fa-clock mr-2"></i><%=project.duration%></span>
 															</div>
 															<div class="project-button-info mt-2">
 																<span class="project-timestamp" title="Current Status"><i class="fas fa-tasks mr-2"></i><%=project.status%></span>


### PR DESCRIPTION
#### Category
- [ ] Bug Fix
- [ ] New Feature
- [x] Hotfix

#### Related issues:
- fixes #136

#### What does this PR do?
Adds an entry field in the portal for project end dates and displays an accurate project duration on the projects page.

#### Notes for Reviewer (@cdconn00)
End dates that are invalid or left blank will default to 01-01-1900 in the database, but are displayed as '12-31-1899' when converted using toLocaleDateString(). Any project with 01-01-1900 or NULL as the end date is treated as ongoing, and displays the time since the start date under 'duration'.


